### PR TITLE
Allow developer to choose store instead of Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ const ƨ = require('sologenic-xrpl-stream-js');
       },
       // Sologenic Options
       {
+        store: "redis", // Specify store
         redis: {
           host: '127.0.0.1',
           port: 6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,6 +558,14 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mysql": {
+      "version": "2.15.8",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.8.tgz",
+      "integrity": "sha512-l0TUdg6KDEaLO75/yjdjksobJDRWv8iZlpRfv/WW1lQZCQDKdTDnKCkeH10oapzP/JTuKiTy6Cvq/sm/0GgcUw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "12.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
@@ -1939,8 +1947,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cp-file": {
       "version": "6.2.0",
@@ -3738,8 +3745,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4400,6 +4406,51 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mysql": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.17.1.tgz",
+      "integrity": "sha512-7vMqHQ673SAk5C8fOzTG2LpPcf3bNt0oL3sFpxPEEFp1mdlDcrLK0On7z8ZYKaaHrHwNcQ/MTUz7/oobZ2OyyA==",
+      "requires": {
+        "bignumber.js": "7.2.1",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "neo-async": {
       "version": "2.6.1",
@@ -5212,8 +5263,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -5885,6 +5935,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sqlstring": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
     "stack-utils": {
       "version": "1.0.2",
@@ -7010,8 +7065,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -508,6 +508,14 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/bson": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
+      "integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -557,6 +565,15 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
+    },
+    "@types/mongodb": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.12.tgz",
+      "integrity": "sha512-gWIdrA8YKC4OetBk4eT5Zsp4p3oy/BJQKt80tXfgPnfBuLigumcmwNZseVSkLQJ3XkN/1OR0/kIunGWlew3rmQ==",
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
     },
     "@types/mysql": {
       "version": "2.15.8",
@@ -1166,6 +1183,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "bson": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4253,6 +4275,12 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -4365,6 +4393,17 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
+    },
+    "mongodb": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.0.tgz",
+      "integrity": "sha512-W90jm/n8F0Edm47ljkVRK9l8qGW9g8T9ZSiZWRiUP58wLhsCJCeN/JxdpVnH0CUwwAw2hITUcCo9x58udpX2Uw==",
+      "requires": {
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
     },
     "mount-point": {
       "version": "3.0.0",
@@ -5512,6 +5551,22 @@
       "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
       "dev": true
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+        }
+      }
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -5703,6 +5758,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -5711,8 +5775,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -5822,6 +5885,15 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
       }
     },
     "spawn-wrap": {

--- a/package.json
+++ b/package.json
@@ -52,11 +52,13 @@
   "dependencies": {
     "@types/ioredis": "^4.0.19",
     "@types/mathjs": "6.0.2",
+    "@types/mongodb": "^3.3.12",
     "@types/mysql": "^2.15.8",
     "@types/node": "12.11.5",
     "@types/uuid": "^3.4.6",
     "ioredis": "^4.14.1",
     "mathjs": "6.2.3",
+    "mongodb": "^3.4.0",
     "mysql": "^2.17.1",
     "ripple-lib": "1.3.4",
     "uuid": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
   "dependencies": {
     "@types/ioredis": "^4.0.19",
     "@types/mathjs": "6.0.2",
+    "@types/mysql": "^2.15.8",
     "@types/node": "12.11.5",
     "@types/uuid": "^3.4.6",
     "ioredis": "^4.14.1",
     "mathjs": "6.2.3",
+    "mysql": "^2.17.1",
     "ripple-lib": "1.3.4",
     "uuid": "^3.3.3"
   },

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -9,7 +9,7 @@ export class SologenicError extends Error {
     return [
       { id: '1000', message: 'unspecified_error' },
       { id: '1001', message: 'sologenic_constructor_error' },
-      { id: '1002', message: 'redis_initialization_failed' },
+      { id: '1002', message: 'store_initialization_failed' },
       { id: '1003', message: 'connection_error' },
       { id: '1004', message: 'unspecified_ripple_error' },
       { id: '1005', message: 'ripple_ws_connection_error' },

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -83,7 +83,7 @@ export class SologenicTxHandler extends EventEmitter {
         Initialize TXMQƨ (Sologenic Transaction Message Queue)
       */
       try {
-        this.txmq = new TXMQƨ(sologenicOptions[sologenicOptions.store]); // Pass on the connection details based on specified store
+        this.txmq = new TXMQƨ(sologenicOptions.store, sologenicOptions[sologenicOptions.store]); // Pass on the connection details based on specified store
       } catch (error) {
         throw new SologenicError('1002');
       }

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -20,17 +20,17 @@ export class SologenicTxHandler extends EventEmitter {
   protected math: any;
 
   /**
-   * Constructor 
-   * 
-   * @param rippleApiOptions This parameter is used to construct ripple-lib and takes in:     
+   * Constructor
+   *
+   * @param rippleApiOptions This parameter is used to construct ripple-lib and takes in:
           server?: string;
           feeCushion?: number; // This property is overridden by Sologenic to 1
           maxFeeXRP?: string;
           trace?: boolean;
           proxy?: string;
           timeout?: number; // This property is overridden by Sologenic to 1000000
-        
-   * @param sologenicOptions 
+
+   * @param sologenicOptions
         {
           redis?: {
             port?: Number;
@@ -49,7 +49,7 @@ export class SologenicTxHandler extends EventEmitter {
   ) {
     super();
     try {
-      /* Initialize RippleAPI driven from the ripple-lib. Sologenic uses the following methods from this library: 
+      /* Initialize RippleAPI driven from the ripple-lib. Sologenic uses the following methods from this library:
       connect()
       on()
       isValidAddress()
@@ -83,7 +83,7 @@ export class SologenicTxHandler extends EventEmitter {
         Initialize TXMQƨ (Sologenic Transaction Message Queue)
       */
       try {
-        this.txmq = new TXMQƨ(sologenicOptions!.redis); // Pass on the Redis connection details
+        this.txmq = new TXMQƨ(sologenicOptions[sologenicOptions.store]); // Pass on the connection details based on specified store
       } catch (error) {
         throw new SologenicError('1002');
       }
@@ -774,7 +774,7 @@ export class SologenicTxHandler extends EventEmitter {
         if (exists) {
           // only if the result from the closed ledger is tesSUCCESS, consider this transaction to be final
           if (validate.outcome.result === 'tesSUCCESS') {
-            /* 
+            /*
               add them to `validated` queue for archiving. This queue is not processed and is just for the records.
               Suggestion: add a TTL to these transactions in this queue to avoid overloading Redis and possibly move these
               transactions to a database

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -45,6 +45,9 @@ export class SologenicTxHandler extends EventEmitter {
             user?: string;
             password?: string;
             database?: string;
+          };
+          mongo?: {
+            uri: string
           }
         }
 
@@ -90,7 +93,7 @@ export class SologenicTxHandler extends EventEmitter {
         Initialize TXMQƨ (Sologenic Transaction Message Queue)
       */
       try {
-        this.txmq = new TXMQƨ(sologenicOptions.store, sologenicOptions[sologenicOptions.store]); // Pass on the connection details based on specified store
+        this.txmq = new TXMQƨ(sologenicOptions.store || "redis", sologenicOptions[sologenicOptions.store]); // Pass on the connection details based on specified store
       } catch (error) {
         throw new SologenicError('1002');
       }

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -33,12 +33,19 @@ export class SologenicTxHandler extends EventEmitter {
    * @param sologenicOptions
         {
           redis?: {
-            port?: Number;
-            host?: String;
-            family?: Number;
-            password?: String;
-            db?: Number;
+            port?: number;
+            host?: string;
+            family?: number;
+            password?: string;
+            db?: number;
           };
+          mysql?: {
+            port?: number;
+            host?: string;
+            user?: string;
+            password?: string;
+            database?: string;
+          }
         }
 
    */

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -32,6 +32,7 @@ export class SologenicTxHandler extends EventEmitter {
 
    * @param sologenicOptions
         {
+          store: string;
           redis?: {
             port?: number;
             host?: string;

--- a/src/lib/stxmq.ts
+++ b/src/lib/stxmq.ts
@@ -113,7 +113,9 @@ export class TXMQƨ {
             `,
             (err: any, result: any) => {
               if (err) { reject(err); }
-              resolve(result);
+              resolve(
+                result.map((i: any) => i.element)
+              );
             }
           );
           const element = elements.find((el: string) => {
@@ -157,7 +159,9 @@ export class TXMQƨ {
             "SELECT * FROM sologenic_generated",
             (err: any, results: any) => {
               if (err) { reject(err); }
-              resolve(results);
+              resolve(
+                results.map((i: any) => i.element)
+              );
             }
           );
         });
@@ -224,7 +228,9 @@ export class TXMQƨ {
           "SELECT * FROM sologenic_generated",
           (err: any, results: any) => {
             if (err) { reject(err); }
-            resolve(results);
+            resolve(
+              results.map((i: any) => i.element)
+            );
           }
         );
       });
@@ -235,7 +241,7 @@ export class TXMQƨ {
       const r: any = await new Promise((resolve, reject) => {
         this.datastore.store.query(
           "DELETE FROM sologenic_generated WHERE element = ?",
-          element,
+          [element],
           (err: any, results: any) => {
             if (err) { reject(err); }
             resolve(results.affectedRows);

--- a/src/lib/stxmq.ts
+++ b/src/lib/stxmq.ts
@@ -239,7 +239,7 @@ export class TXMQƨ {
       }
       return false;
     } catch (error) {
-      throw new Error("Can't get TX from Redis");
+      throw new Error("Can't get TX from store");
     }
   }
 
@@ -302,7 +302,7 @@ export class TXMQƨ {
     }
     return false;
   } catch (error) {
-      throw new Error("Can't get TX from Redis");
+      throw new Error("Can't get TX from store");
     }
   }
   /**
@@ -333,7 +333,7 @@ export class TXMQƨ {
       }
       return false;
     } catch (error) {
-      throw new Error("Can't get TX from Redis");
+      throw new Error("Can't get TX from store");
     }
   }
 }

--- a/src/lib/stxmq.ts
+++ b/src/lib/stxmq.ts
@@ -8,8 +8,8 @@ export class TXMQƨ {
   constructor(store: string, config: any) {
     try {
       const stores: any = {
-        redis: new Redis(config),
-        mysql: MySQL.createConnection(config)
+        redis: store === "redis" ? new Redis(config) : null,
+        mysql: store === "mysql" ? MySQL.createConnection(config) : null
       };
       this.datastore = {
         type: store,
@@ -26,15 +26,16 @@ export class TXMQƨ {
   // Only if store type is "mysql"
   public connectToMySQL(): void {
     this.datastore.store.connect((err: any) => {
-      if (err) throw new Error("Cannot connect to MySQL");
+      if (err) { throw new Error("Cannot connect to MySQL"); }
     });
     this.datastore.store.query(
       `
         CREATE TABLE IF NOT EXISTS sologenic_generated (
+          id INTEGER AUTO_INCREMENT
           element VARCHAR (255) NOT NULL
         )
       `, (err: any, result: any) => {
-        if (err) throw new Error("Error occured while generating table");
+        if (err) { throw new Error("Error occured while generating table"); }
         console.log(result);
       }
     );
@@ -66,9 +67,9 @@ export class TXMQƨ {
             `INSERT INTO sologenic_generated (
               element
             ) VALUES ("${JSON.stringify(element)}")`,
-            (err: any, result: any) => {
-              if (err) reject(err);
-              resolve(result);
+            (err: any, obj: any) => {
+              if (err) { reject(err); }
+              resolve(obj);
             }
           );
         });
@@ -111,7 +112,7 @@ export class TXMQƨ {
               SELECT * FROM sologenic_generated
             `,
             (err: any, result: any) => {
-              if (err) reject(err);
+              if (err) { reject(err); }
               resolve(result);
             }
           );
@@ -130,64 +131,121 @@ export class TXMQƨ {
       }
       return undefined;
     } catch (error) {
-      throw new Error("Can't get TX from Redis");
+      throw new Error("Can't get TX from store");
     }
   }
   /**
    *
    * @param queue
    */
-  public async getAll(queue: string): Promise<Array<MQTX>> {
+  public async getAll(queue?: string): Promise<Array<MQTX>> {
     try {
-      const elements = await this.redis.lrange(queue, 0, -1);
+      if (this.datastore.type === "redis") {
+        const elements = await this.datastore.store.lrange(queue, 0, -1);
 
-      if (elements.length > 0) {
-        return elements.map((el: string) => {
-          return JSON.parse(el);
-        });
-      } else {
-        return [];
-      }
-    } catch (error) {
-      throw new Error("Can't get TX from Redis");
-    }
-  }
-  /**
-   *
-   * @param queue
-   */
-  public async pop(queue: string): Promise<boolean | Array<any>> {
-    try {
-      const element = await this.redis.blpop(queue, 1);
-
-      if (element && element.length > 0) {
-        return JSON.parse(element[1]);
-      } else {
-        return false;
-      }
-    } catch (error) {
-      throw new Error("Can't get TX from Redis");
-    }
-  }
-
-  public async del(queue: string, id: string): Promise<boolean | Array<any>> {
-    try {
-      const elements = await this.redis.lrange(queue, 0, -1);
-      const element = elements.find((el: string) => {
-        const parsed = JSON.parse(el);
-        if (parsed.id === id) {
-          return parsed;
+        if (elements.length > 0) {
+          return elements.map((el: string) => {
+            return JSON.parse(el);
+          });
+        } else {
+          return [];
         }
+      }
+      if (this.datastore.type === "mysql") {
+        const elements: any = await new Promise((resolve, reject) => {
+          this.datastore.store.query(
+            "SELECT * FROM sologenic_generated",
+            (err: any, results: any) => {
+              if (err) { reject(err); }
+              resolve(results);
+            }
+          );
+        });
+        if (elements.length > 0) {
+          return elements.map((el: string) => JSON.parse(el));
+        } else {
+          return [];
+        }
+      }
+      return [];
+    } catch (error) {
+      throw new Error("Can't get TX from store");
+    }
+  }
+  /**
+   *
+   * @param queue
+   */
+  public async pop(queue?: string): Promise<boolean | Array<any>> {
+    try {
+      if (this.datastore.type === "redis") {
+        const element = await this.datastore.store.blpop(queue, 1);
+        return (element && element.length > 0) ? [JSON.parse(element[1])] : false;
+      }
+      if (this.datastore.type === "mysql") {
+        const element: any = await new Promise((resolve, reject) => {
+          this.datastore.store.query(
+            `DELETE FROM sologenic_generated WHERE id = (SELECT MAX(id) FROM sologenic_generated)`,
+            (err: any, results: any) => {
+              if (err) { reject(err); }
+              resolve(results.affectedRows);
+            }
+          );
+        });
+        return (element && element > 0) ? [element] : false;
+      }
+      return false;
+    } catch (error) {
+      throw new Error("Can't get TX from Redis");
+    }
+  }
+
+  public async del(queue: string | undefined, id: string): Promise<boolean | Array<any>> {
+    try {
+      if (this.datastore.type === "redis") {
+        const elements = await this.datastore.store.lrange(queue, 0, -1);
+        const element = elements.find((el: string) => {
+        const parsed = JSON.parse(el);
+        return parsed.id === id;
       });
 
-      const result = await this.redis.lrem(queue, 1, element);
+      const result = await this.datastore.store.lrem(queue, 1, element);
 
       if (result) {
         return true;
       } else {
         return false;
       }
-    } catch (error) {
+    }
+
+    if (this.datastore.type === "mysql") {
+      const elements: any = await new Promise((resolve, reject) => {
+        this.datastore.store.query(
+          "SELECT * FROM sologenic_generated",
+          (err: any, results: any) => {
+            if (err) { reject(err); }
+            resolve(results);
+          }
+        );
+      });
+      const element = elements.find((el: string) => {
+        const parsed = JSON.parse(el);
+        return parsed.id === id;
+      });
+      const r: any = await new Promise((resolve, reject) => {
+        this.datastore.store.query(
+          "DELETE FROM sologenic_generated WHERE element = ?",
+          element,
+          (err: any, results: any) => {
+            if (err) { reject(err); }
+            resolve(results.affectedRows);
+          }
+        );
+      });
+      return r > 0;
+    }
+    return false;
+  } catch (error) {
       throw new Error("Can't get TX from Redis");
     }
   }
@@ -195,14 +253,25 @@ export class TXMQƨ {
    *
    * @param queue
    */
-  public async delAll(queue: string): Promise<boolean> {
+  public async delAll(queue?: string): Promise<boolean> {
     try {
-      const elements = await this.redis.del(queue);
-      if (elements > 0) {
-        return true;
-      } else {
-        return false;
+      if (this.datastore.type === "redis") {
+        const elements = await this.datastore.store.del(queue);
+        return elements > 0;
       }
+      if (this.datastore.type === "mysql") {
+        const elements: any = await new Promise((resolve, reject) => {
+          this.datastore.store.query(
+            "DELETE FROM sologenic_generated",
+            (err: any, results: any) => {
+              if (err) { reject(err); }
+              resolve(results.affectedRows);
+            }
+          );
+        });
+        return elements > 0;
+      }
+      return false;
     } catch (error) {
       throw new Error("Can't get TX from Redis");
     }

--- a/src/lib/stxmq.ts
+++ b/src/lib/stxmq.ts
@@ -1,15 +1,43 @@
 import Redis from 'ioredis';
+import MySQL from 'mysql';
 import { v4 as uuid } from 'uuid';
 import { MQTX } from '../types';
 
 export class TXMQƨ {
-  private redis: any;
-  constructor(config: any) {
+  private datastore: { type: string; store: any } = { type: "", store: null };
+  constructor(store: string, config: any) {
     try {
-      this.redis = new Redis(config);
+      const stores: any = {
+        redis: new Redis(config),
+        mysql: MySQL.createConnection(config)
+      };
+      this.datastore = {
+        type: store,
+        store: stores[store]
+      }
+      if (this.datastore.type === "mysql") {
+        this.connectToMySQL();
+      }
     } catch (error) {
       throw new Error('Unable to initialize TXMQ');
     }
+  }
+
+  // Only if store type is "mysql"
+  public connectToMySQL(): void {
+    this.datastore.store.connect((err: any) => {
+      if (err) throw new Error("Cannot connect to MySQL");
+    });
+    this.datastore.store.query(
+      `
+        CREATE TABLE IF NOT EXISTS sologenic_generated (
+          element VARCHAR (255) NOT NULL
+        )
+      `, (err: any, result: any) => {
+        if (err) throw new Error("Error occured while generating table");
+        console.log(result);
+      }
+    );
   }
 
   /**
@@ -18,20 +46,41 @@ export class TXMQƨ {
    * @param data
    * @param id
    */
-  public async add(queue: string, data: object, id?: string): Promise<MQTX> {
+  public async add(queue: string | undefined, data: object, id?: string): Promise<MQTX | undefined> {
     try {
       const element = {
         id: typeof id !== 'undefined' ? id : uuid(),
         data
       };
-      const result = await this.redis.rpush(queue, JSON.stringify(element));
-      if (result > 0) {
-        return element;
-      } else {
-        throw new Error("Can't add TX to Redis");
+      if (this.datastore.type === "redis") {
+        const result = await this.datastore.store.rpush(queue, JSON.stringify(element));
+        if (result > 0) {
+          return element;
+        } else {
+          throw new Error("Can't add TX to Redis");
+        }
       }
+      if (this.datastore.type === "mysql") {
+        const result = await new Promise((resolve, reject) => {
+          this.datastore.store.query(
+            `INSERT INTO sologenic_generated (
+              element
+            ) VALUES ("${JSON.stringify(element)}")`,
+            (err: any, result: any) => {
+              if (err) reject(err);
+              resolve(result);
+            }
+          );
+        });
+        if (result) {
+          return element;
+        } else {
+          throw new Error("Can't add TX to MySQL");
+        }
+      }
+      return undefined;
     } catch (error) {
-      throw new Error("Can't add TX to Redis");
+      throw new Error("Can't add TX to store");
     }
   }
   /**
@@ -39,20 +88,47 @@ export class TXMQƨ {
    * @param queue
    * @param id
    */
-  public async get(queue: string, id: string): Promise<MQTX | undefined> {
+  public async get(queue: string | undefined, id: string): Promise<MQTX | undefined> {
     try {
-      const elements = await this.redis.lrange(queue, 0, -1);
-      const element = elements.find((el: string) => {
-        const parsed = JSON.parse(el);
-        if (parsed.id === id) {
-          return parsed;
+      if (this.datastore.type === "redis") {
+        const elements = await this.datastore.store.lrange(queue, 0, -1);
+        const element = elements.find((el: string) => {
+          const parsed = JSON.parse(el);
+          if (parsed.id === id) {
+            return parsed;
+          }
+        });
+        if (element) {
+          return JSON.parse(element);
+        } else {
+          return undefined;
         }
-      });
-      if (element) {
-        return JSON.parse(element);
-      } else {
-        return undefined;
       }
+      if (this.datastore.type === "mysql") {
+        const elements: any = await new Promise((resolve, reject) => {
+          this.datastore.store.query(
+            `
+              SELECT * FROM sologenic_generated
+            `,
+            (err: any, result: any) => {
+              if (err) reject(err);
+              resolve(result);
+            }
+          );
+          const element = elements.find((el: string) => {
+            const parsed = JSON.parse(el);
+            if (parsed.id === id) {
+              return parsed;
+            }
+          });
+          if (element) {
+            return JSON.parse(element);
+          } else {
+            return undefined;
+          }
+        });
+      }
+      return undefined;
     } catch (error) {
       throw new Error("Can't get TX from Redis");
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './txmq';
 export * from './sologenicoptions';
+export * from './storesoptions';

--- a/src/types/sologenicoptions.d.ts
+++ b/src/types/sologenicoptions.d.ts
@@ -1,13 +1,11 @@
 import { EventEmitter } from 'events';
+import { IRedisOptions, IMongoOptions, IMySQLOptions } from './storesoptions';
 
 export interface TransactionHandlerOptions {
-  redis?: {
-    port?: number;
-    host?: string;
-    family?: number;
-    password?: string;
-    db?: number;
-  };
+  store: "mysql" | "redis" | "mongo";
+  redis?: IRedisOptions;
+  mysql?: IMySQLOptions;
+  mongo?: IMongoOptions;
 }
 export declare interface ISologenicTxHandler extends EventEmitter {
   on(event: string, listener: Function): this;

--- a/src/types/storesoptions.ts
+++ b/src/types/storesoptions.ts
@@ -7,11 +7,8 @@ export interface IRedisOptions {
 }
 
 export interface IMongoOptions {
-  port?: number;
-  host?: string;
-  user?: string;
-  password?: string;
-  db?: string;
+  uri: string;
+  database?: string;
 }
 
 export interface IMySQLOptions {

--- a/src/types/storesoptions.ts
+++ b/src/types/storesoptions.ts
@@ -1,0 +1,23 @@
+export interface IRedisOptions {
+  port?: number;
+  host?: string;
+  family?: number;
+  password?: string;
+  db?: number;
+}
+
+export interface IMongoOptions {
+  port?: number;
+  host?: string;
+  user?: string;
+  password?: string;
+  db?: string;
+}
+
+export interface IMySQLOptions {
+  port?: number;
+  host?: string;
+  user?: string;
+  password?: string;
+  database?: string;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
     "ordered-imports": false,
     "no-submodule-imports": false,
     "array-type": [false, "array"],
-    "no-bitwise": false
+    "no-bitwise": false,
+    "no-console": false
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

[#1 ](https://github.com/sologenic/sologenic-xrpl-stream-js/issues/1)

* **What is the new behavior (if this is a feature change)?**

Developer can indicate store to use. There is presently support for Redis, MySQL and MongoDB. Configuration is loaded based on specified store. If for example, developer specifies "mysql", they must also include "mysql" key with configuration.

* **Other information**:
