### PR TITLE
Testing updates and minor fixes to TX handler

### DIFF
--- a/src/lib/error.spec.ts
+++ b/src/lib/error.spec.ts
@@ -1,0 +1,42 @@
+import test from 'ava';
+import { SologenicError } from './error';
+
+test('check for duplicate error ids and messages', async function(t) {
+    let errorCodes = SologenicError.getErrorCodes();
+
+    for (var i in errorCodes) {
+        let errorId = SologenicError.getErrorCodeByMessage(errorCodes[i].message);
+        let message = SologenicError.getErrorCodeById(errorCodes[i].id);
+       
+        t.true(typeof(errorId) == 'string');
+        t.true(typeof(message) == 'string');          
+
+        await new Promise((resolve) => {
+            let count = 0;
+
+            for (var index in errorCodes) {
+                if (errorCodes[index].id == errorId) {
+                    count++;
+                }
+            }
+
+            resolve(count);
+        }).then(function(value) {
+            t.is(value, 1);
+        });
+
+        await new Promise((resolve) => {
+            let count = 0;
+
+            for (var index in errorCodes) {
+                if (errorCodes[index].message == message) {
+                    count++;
+                }
+            }
+
+            resolve(count);
+        }).then(function(value) {
+            t.is(value, 1);
+        });
+    }       
+});

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -5,7 +5,8 @@ export class SologenicError extends Error {
     this.message = this._getError(status);
     Object.setPrototypeOf(this, SologenicError.prototype);
   }
-  public _getError(errorId: string): string {
+  
+  public static getErrorCodes(): Array<any> {
     return [
       { id: '1000', message: 'unspecified_error' },
       { id: '1001', message: 'sologenic_constructor_error' },
@@ -16,6 +17,20 @@ export class SologenicError extends Error {
       { id: '1006', message: 'unable_to_validate_missed_transactions' },
       { id: '2000', message: 'invalid_xrp_address' },
       { id: '2001', message: 'invalid_xrp_secret' }
-    ].find(e => e.id === errorId)!.message;
+    ]
+  }
+
+  public static getErrorCodeById(errorId: string): string {
+    return SologenicError.getErrorCodes().find(
+      e => e.id === errorId)!.message;
+  }
+
+  public static getErrorCodeByMessage(message: string): string {
+    return SologenicError.getErrorCodes().find(
+      e => e.message === message)!.id;
+  }
+
+  public _getError(errorId: string): string {
+    return SologenicError.getErrorCodeById(errorId);
   }
 }

--- a/src/lib/queues/hash.ts
+++ b/src/lib/queues/hash.ts
@@ -79,21 +79,20 @@ export default class HashQueue implements IQueue {
    * @description pop an element off the end of the queue
    */
 
-  public async pop(queue: string): Promise<boolean | any[]> {
+  public async pop(queue: string): Promise<MQTX | boolean> {
     return new Promise((resolve, reject) => {
       try {
         if (this._exist(queue)) {
           let data = this.hash.get(queue) || [];
 
           if (data.length > 0) {           
-            data.pop();
-            this.hash.set(queue, data);
+            let element = data.pop();
  
-            resolve(data.length === (this.hash.get(queue) || []).length ? true : false);
+            this.hash.set(queue, data);
+            resolve(element);
           }
+          resolve(false);
         }
-
-        reject(false);
       } catch (error) {
         reject(false);
       }
@@ -106,19 +105,19 @@ export default class HashQueue implements IQueue {
    * @param id
    * @description delete an object by id from the queue
    */
-  public async del(queue: string, id: string): Promise<boolean | any[]> {
+  public async del(queue: string, id: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       try {
         if (this._exist(queue)) {
-          let data = this.hash.get(queue) || [];
+          const data = this.hash.get(queue) || [];
 
-          let filtered = data.filter(function(e) {
+          const filtered = data.filter(function(e) {
             return e.id !== id;
           });
           
           this.hash.set(queue, filtered);
 
-          resolve(data.length-1 === (this.hash.get(queue) || []).length ? true : false);
+          resolve((data.length - 1) === (this.hash.get(queue) || []).length);
         } else {
           resolve(false);
         }

--- a/src/lib/queues/hash.ts
+++ b/src/lib/queues/hash.ts
@@ -3,10 +3,20 @@ import { MQTX, IQueue } from '../../types';
 import { v4 as uuid } from 'uuid';
 
 export default class HashQueue implements IQueue {
-  private hash = new Map<any, Array<MQTX>>(); 
+  private hash: Map<string, Array<MQTX>> = new Map<string, Array<MQTX>>(); 
 
   constructor(options: any) { 
     options;
+  }
+
+  private _exist(queue: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      try {
+        resolve(this.hash.has(queue));
+      } catch (error) {
+        reject(false);
+      }
+    });
   }
 
   /**
@@ -14,14 +24,15 @@ export default class HashQueue implements IQueue {
    * @param queue
    * @param data
    * @param id
+   * @description add an object to the queue
    */
-  public async add(queue: string, data: object, id?: string): Promise<MQTX> {
+  public async add(queue: string, data: object, id?: string): Promise<MQTX> {   
     const element = {
       id: typeof id !== 'undefined' ? id : uuid(),
       data
     };
 
-    var _queue = this.hash.has(queue) ? this.hash.get(queue) : new Array<MQTX>();
+    var _queue = await this._exist(queue) ? this.hash.get(queue) : new Array<MQTX>();
 
     if (_queue instanceof Array) {
       _queue.push(element);
@@ -36,15 +47,16 @@ export default class HashQueue implements IQueue {
    *
    * @param queue
    * @param id
+   * @description returns a specific object within the queue
    */
   public async get(queue: string, id: string): Promise<MQTX | undefined> {  
-    var _queue = this.hash.has(queue) ? this.hash.get(queue) : new Array<MQTX>();
+    var _queue = await this._exist(queue) ? this.hash.get(queue) : new Array<MQTX>();
 
     var found = undefined;
 
     if (_queue instanceof Array) { 
       _queue.forEach((obj) => {
-        if (obj.id == id)
+        if (obj.id === id)
           found = obj;
       });
     }
@@ -55,63 +67,81 @@ export default class HashQueue implements IQueue {
   /**
    *
    * @param queue
+   * @description returns all elements of the queue
    */
   public async getAll(queue: string): Promise<Array<MQTX>> {
-    return this.hash.has(queue) ? this.hash.get(queue) || [] : [];
+    return await this._exist(queue) ? this.hash.get(queue) || [] : [];
   }
 
   /**
    *
    * @param queue
+   * @description pop an element off the end of the queue
    */
-  public async pop(queue: string): Promise<boolean | Array<any>> {
-    if (this.hash.has(queue)) {
-      var _queue = this.hash.get(queue) || [];
 
-      if (_queue.length > 0 && _queue.pop()) {
-        this.hash.set(queue, _queue);
-      } else {
-        return false;
+  public async pop(queue: string): Promise<boolean | any[]> {
+    return new Promise((resolve, reject) => {
+      try {
+        if (this._exist(queue)) {
+          let data = this.hash.get(queue) || [];
+
+          if (data.length > 0) {           
+            data.pop();
+            this.hash.set(queue, data);
+ 
+            resolve(data.length === (this.hash.get(queue) || []).length ? true : false);
+          }
+        }
+
+        reject(false);
+      } catch (error) {
+        reject(false);
       }
-
-      return _queue;
-    }
-
-    return false;
+    });
   }
 
   /**
    *
    * @param queue
    * @param id
+   * @description delete an object by id from the queue
    */
   public async del(queue: string, id: string): Promise<boolean | any[]> {
-    if (this.hash.has(queue)) {
-      var _queue = this.hash.get(queue) || [];
+    return new Promise((resolve, reject) => {
+      try {
+        if (this._exist(queue)) {
+          let data = this.hash.get(queue) || [];
 
-      _queue.filter(function(value) {
-        return value.id != id;
-      });
+          let filtered = data.filter(function(e) {
+            return e.id !== id;
+          });
+          
+          this.hash.set(queue, filtered);
 
-      this.hash.set(queue, _queue);
-    }
-
-    return false;
+          resolve(data.length-1 === (this.hash.get(queue) || []).length ? true : false);
+        } else {
+          resolve(false);
+        }
+      } catch (error) {
+        reject(false);
+      }
+    });
   }
 
   /**
    *
    * @param queue
+   * @description delete all elements from the queue
    */
-  public async delAll(queue: string): Promise<boolean> {
-    if (this.hash.has(queue)) {     
-      var _queue = new Array<MQTX>();
-
-      this.hash.set(queue, _queue);
-
-      return true;
-    }
-
-    return false;
+  public delAll(queue: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      try {
+        if (this._exist(queue)) {         
+          resolve(this.hash.delete(queue));
+        }
+      } catch (error) {
+        reject(false);
+      }
+    });
   }
-};
+}

--- a/src/lib/queues/redis.spec.ts
+++ b/src/lib/queues/redis.spec.ts
@@ -2,121 +2,141 @@ import test from 'ava';
 
 import RedisQueue from './redis';
 
-test("add to the queue", async t => {
-  let session = new RedisQueue({
-    host: 'localhost',
-    port: 6379,
-    database: 1 
-  });
+const _ = require('underscore');
 
-  let q = "queue";
-  let data = {
-    message: "Hello, World"
+test.before(async t => {
+  _.extend(t.context, {
+    data: {
+      message: "Hello, World"
+    },
+    session: new RedisQueue({})
+  });
+});
+
+test("add to the queue", async t => {
+  var session = (<any>t.context).session;
+  var queue = "add_to_queue";
+  var data = (<any>t.context).data;
+
+  var result = await session.add(queue, data);
+
+  t.true(typeof(result.id) === 'string');
+  t.true(typeof(result.data) === 'object');
+
+  var response = await session.get(queue, result.id) || {
+    id: undefined
   };
 
-  var p = await session.add(q, data);
+  t.true(response.id === result.id);
+});
 
-  if ('message' in data)
-    t.true(p.data['message'] === data['message']);
+test("add to the queue with custom id", async t => {
+  var session = (<any>t.context).session;
+  var queue = "add_to_queue_with_custom_id";
+  var data = (<any>t.context).data;
+  var custom_id = 'foobar';
 
-  t.pass();
+  var result = await session.add(queue, data, custom_id);
+
+  t.true(typeof(result.id) === 'string');
+  t.true(typeof(result.data) === 'object');
+
+  var response = await session.get(queue, custom_id) || {
+    id: undefined
+  };
+
+  t.true(response.id === custom_id);
 });
 
 test('validate retrieve with an invalid object identifier is undefined', async t => {
-  let session = new RedisQueue({
-    host: 'localhost',
-    port: 6379,
-    database: 1 
-  });
+  var session = (<any>t.context).session;
+  var queue = "invalid_object_identifier";
 
-  let q = "queue";
-
-  t.true(await session.get(q, "1") == undefined);
+  t.true(await session.get(queue, "barfoo") === undefined);
 });
 
-test('store and retrieve object', async t => {
-  let session = new RedisQueue({
-    host: 'localhost',
-    port: 6379,
-    database: 1 
-  });
+test('store and retrieve objects', async t => {
+  try {
+    var session = (<any>t.context).session;
+    var queue = "store_and_retrieve";
 
-  let q = "queue"; 
+    await session.delAll(queue);
 
-  let data = {
-    message: "Hello, World"
-  };
+    var objects = [
+      { message: "Message 1" },
+      { message: "Message 2" },
+      { message: "Message 3" },
+      { message: "Message 4" }
+    ];
 
-  var store1 = await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
+    for (var index in objects) {
+      let result = await session.add(queue, objects[index]);
+      let response = await session.get(queue, result.id);
 
-  // Sleep for 500 milliseconds to make sure we can retrieve our value back
-  await new Promise(
-    resolve => setTimeout(resolve, 2500)).then(() => {       
-  });
+      t.true(typeof(result.id) === 'string');
+      t.true(typeof(response.id) === 'string');
 
-  t.log("Attempting to retrieve " + store1.id);
-  
-  var retrieve = await session.get(q, store1.id);
-  
-  if (retrieve) {
-    t.true(retrieve.data['message'] === data['message']);
-  } else {
-    t.fail();
+      t.is(result.id, response.id);
+    }
+
+    let items = await session.getAll(queue);
+
+    if (items) {
+      t.log(items.length);
+      t.log(objects.length);
+      t.true(items.length === objects.length);
+    } else {
+      t.fail("Failing because items.length !== objects.length - 1");
+    }
+  } catch(error) {
+    t.fail(`Failing test, caught an exception = ${error}`);
   }
 });
 
-test('retrieve all objects from data store', async t => {
-  let session = new RedisQueue({
-    host: 'localhost',
-    port: 6379,
-    database: 1 
-  });
+test('delete objects from queue', async t => {
+  try {
+    var session = (<any>t.context).session;
+    var queue = "delete_all_objects_from_queue";
 
-  let q = "queue";
+    var objects = [
+      { message: "Message 1" },
+      { message: "Message 2" },
+      { message: "Message 3" },
+      { message: "Message 4" }
+    ];
 
-  let data = {
-    message: "Hello, World"
-  };
+    for (var index in objects) {
+      await session.add(queue, objects[index]);
+    }
 
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
+    let items = [];
+    items = await session.getAll(queue);
 
-  await new Promise(
-    resolve => setTimeout(resolve, 500)).then(() => {       
-  });
-  
-  var all_data = await session.getAll(q);
+    if (items)
+      t.true(items.length === objects.length, "Checking that items.length === objects.length");
+    else
+      t.fail("Failing test because the items.length !== objects.length");
 
-  t.true(all_data.length > 0);
-});
+    /* Pop an item off the queue */
+    t.true(typeof(await session.pop(queue)) === 'object', "Verify that the returned element is of type 'object'");
 
-test('delete all objects from data store', async t => {
-  let q = "queue";
-  let session = new RedisQueue({
-    host: 'localhost',
-    port: 6379,
-    database: 1 
-  });
+    items = await session.getAll(queue);
 
-  let data = {
-    message: "Hello, World"
-  };
+    /* Delete an item */
+    t.true(await session.del(queue, items[0].id), "Delete the first item");
 
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
-  await session.add(q, data);
+    /* Delete the remaining items */
+    t.true(await session.delAll(queue));
 
-  // Sleep for 500 milliseconds to make sure we can retrieve our value back
-  await new Promise(
-    resolve => setTimeout(resolve, 5000)).then(() => {       
-  });
+    /* Delete an item */
+    t.false(await session.del(queue, items[0].id), "Verify return type is false because there are no more elements to delete");
 
-  t.true(await session.delAll(q));
+    /* Pop an item off the queue */
+    t.false(await session.pop(queue), "Verify return type is false because there are no more elements left to pop");
+
+    items = await session.getAll(queue);
+    items && t.true(items.length === 0, "Checking that items.length === 0");
+  } catch (error) {
+    t.fail(`Failing test, caught an exception = ${error}`);
+  }
 });

--- a/src/lib/queues/redis.ts
+++ b/src/lib/queues/redis.ts
@@ -82,25 +82,29 @@ export default class RedisQueue implements IQueue {
      *
      * @param queue
      */
-    public async pop(queue: string): Promise<boolean | Array<any>> {
+    public async pop(queue: string): Promise<MQTX | boolean> {
       try {
         const element = await this.redis.blpop(queue, 1);
-  
-        if (element && element.length > 0) {
-          return JSON.parse(element[1]);
-        } else {
-          return false;
-        }
-      } catch (error) {
+
+        /*
+        If the returned element not undefined
+        and its length is greater than 0, return the object
+        */
+
+        return (element && element.length > 0) ? JSON.parse(element[1]) : false;
+
+        } catch (error) {
         throw new Error("Can't get TX from Redis");
       }
     }
   
-    public async del(queue: string, id: string): Promise<boolean | Array<any>> {
+    public async del(queue: string, id: string): Promise<boolean> {
       try {
         const elements = await this.redis.lrange(queue, 0, -1);
+
         const element = elements.find((el: string) => {
           const parsed = JSON.parse(el);
+
           if (parsed.id === id) {
             return parsed;
           }

--- a/src/lib/sologenictxhandler.spec.ts
+++ b/src/lib/sologenictxhandler.spec.ts
@@ -1,5 +1,136 @@
 import test from 'ava';
+import util from 'util';
 
-test('sologenictxhandler', t => {
-  t.pass();
+import *  as SologenicTypes from '../types';
+
+import SologenicTxHandler from './sologenictxhandler';
+
+import { SologenicError } from './error';
+import { EventEmitter } from 'events';
+
+const axios = require('axios');
+const _ = require('underscore');
+
+test.before(async t => { 
+  _.extend(t.context, {  
+    server: "wss://s.devnet.rippletest.net:51233",
+    faucet: "https://faucet.devnet.rippletest.net/accounts",
+    invalid_account: {
+      address: 'foo',
+      secret: 'bar'
+    }
+  });
+
+  let result = await axios.post((<any>t.context).faucet);
+
+  // Give the XRPL some (2.5s) time to settle before continuing since
+  // we want to make sure our address is recognized by the ledger
+  // otherwise we get an 'invalid_xrp_address' error.
+
+  await util.promisify(setTimeout)(2500);
+
+  t.is(typeof(result.data!.account), 'object');
+  
+  _.extend(t.context, {
+    valid_account: { 
+      address: result.data.account.address,
+      secret: result.data.account.secret
+    }
+  });
+
+  t.true((<any>(<any>t.context).valid_account).address !== undefined);
+  t.true((<any>(<any>t.context).invalid_account).address !== undefined);
+});
+
+test('sologenic tx hash initialization', async t => {
+  let rippleOptions: SologenicTypes.RippleAPIOptions = {
+    server: (<any>t.context).server
+  };
+
+  let thOptions: SologenicTypes.TransactionHandlerOptions = { 
+    queueType: SologenicTypes.QUEUE_TYPE_STXMQ_HASH
+  };
+
+  let handler = new SologenicTxHandler(rippleOptions, thOptions);
+  await handler.connect();
+
+  const valid_account: SologenicTypes.Account = (<any>(<any>t.context).valid_account);
+  const invalid_account: SologenicTypes.Account = (<any>(<any>t.context).invalid_account);
+
+  await t.throwsAsync<SologenicError>(handler.setAccount(invalid_account));
+
+  await t.notThrowsAsync(handler.setAccount(valid_account));
+});
+
+test('sologenic tx redis initialization', async t => {
+  let rippleOptions: SologenicTypes.RippleAPIOptions = {
+    server: (<any>t.context).server
+  };
+
+  let thOptions: SologenicTypes.TransactionHandlerOptions = { 
+    queueType: SologenicTypes.QUEUE_TYPE_STXMQ_REDIS
+  };
+
+  let handler = new SologenicTxHandler(rippleOptions, thOptions);
+  await handler.connect();
+
+  const valid_account: SologenicTypes.Account = (<any>(<any>t.context).valid_account);
+  const invalid_account: SologenicTypes.Account = (<any>(<any>t.context).invalid_account);
+
+  await t.throwsAsync<SologenicError>(handler.setAccount(invalid_account));
+
+  await t.notThrowsAsync(handler.setAccount(valid_account));
+});
+
+test('submit transaction to xrp ledger', async t => {
+  let rippleOptions: SologenicTypes.RippleAPIOptions = {
+    server: (<any>t.context).server
+  };
+
+  let thOptions: SologenicTypes.TransactionHandlerOptions = { 
+    queueType: SologenicTypes.QUEUE_TYPE_STXMQ_HASH
+  };
+    
+  let handler = new SologenicTxHandler(rippleOptions, thOptions);
+
+  await handler.connect();
+  await handler.setAccount(<any>(<any>t.context).valid_account);
+
+  let tx: SologenicTypes.TX = {
+    Account: <any>(<any>t.context).valid_account.address,
+    TransactionType: "AccountSet",
+  };
+
+  let transaction: SologenicTypes.TransactionObject = handler.submit(tx);
+  let events: EventEmitter = transaction!.events;
+
+  t.true(events instanceof EventEmitter);
+
+  events.on('queued', function() {    
+    // console.debug("Queued event = " + e);
+    // console.debug(e);
+  }).on('dispatched', function() {
+    // console.debug("Dispatched event = " + e);
+    // console.debug(e);
+  }).on('requeued', function() {
+    // console.debug("Requeued event = " + e);
+    // console.debug(e);
+  }).on('warning', function() {
+    // console.debug("Warning event = " + e);
+    // console.debug(e);
+  }).on('validated', function() { 
+    // console.debug("Validated event = " + e);
+    // console.debug(e);
+  });
+
+  let rtx: SologenicTypes.ResolvedTX = await transaction.promise;
+
+  t.log(rtx);
+
+  t.true(typeof(rtx.accountSequence) === 'number', 'Verify account sequence is a number');
+  t.true(typeof(rtx.fee) === 'string', 'Verify fee is a string (0.00012 currently)');
+  t.true(typeof(rtx.ledgerVersion) === 'number', 'Verify ledger version');
+  t.true(typeof(rtx.timestamp) === 'string', 'Verify timestamp');
+
+  t.true(rtx.hash.length === 64);
 });

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -7,6 +7,7 @@ import util from 'util';
 import { TXMQƨ } from './stxmq';
 import { EventEmitter } from 'events';
 import { v4 as uuid } from 'uuid';
+
 const _ = require('underscore');
 
 export default class SologenicTxHandler extends EventEmitter {
@@ -21,17 +22,17 @@ export default class SologenicTxHandler extends EventEmitter {
   protected math: any;
 
   /**
-   * Constructor 
-   * 
-   * @param rippleApiOptions This parameter is used to construct ripple-lib and takes in:     
+   * Constructor
+   *
+   * @param rippleApiOptions This parameter is used to construct ripple-lib and takes in:
           server?: string;
           feeCushion?: number; // This property is overridden by Sologenic to 1
           maxFeeXRP?: string;
           trace?: boolean;
           proxy?: string;
           timeout?: number; // This property is overridden by Sologenic to 1000000
-        
-   * @param sologenicOptions 
+
+   * @param sologenicOptions
         {
           queueType?: QueueType;
 
@@ -67,7 +68,7 @@ export default class SologenicTxHandler extends EventEmitter {
   ) {
     super();
     try {
-      /* Initialize RippleAPI driven from the ripple-lib. Sologenic uses the following methods from this library: 
+      /* Initialize RippleAPI driven from the ripple-lib. Sologenic uses the following methods from this library:
       connect()
       on()
       isValidAddress()
@@ -120,11 +121,20 @@ export default class SologenicTxHandler extends EventEmitter {
   }
 
   /**
+   * Expose the ripple API so that our tests can use it to check
+   * transaction status and states.
+   */
+
+  public getRippleApi(): RippleAPI {
+    return this.rippleApi;
+  }
+
+  /**
    * Connect to various services: RippleAPI, fetch current ledger state.
    */
   public async connect(): Promise<this> {
     try {
-      await this.rippleApi.connect();
+      await this.getRippleApi().connect();
       await this._connected();
 
       // Start the dispatcher listener
@@ -152,7 +162,7 @@ export default class SologenicTxHandler extends EventEmitter {
       /*
         Is this a valid XRP address?
       */
-      if (this.rippleApi.isValidAddress(account.address)) {
+      if (this.getRippleApi().isValidAddress(account.address)) {
         this.account = account.address;
       } else {
         throw new SologenicError('2000', new RippleError.ValidationError());
@@ -160,7 +170,7 @@ export default class SologenicTxHandler extends EventEmitter {
       /*
         Is this a valid XRP secret?
       */
-      if (this.rippleApi.isValidSecret(account.secret)) {
+      if (this.getRippleApi().isValidSecret(account.secret)) {
         this.secret = account.secret;
       } else {
         throw new SologenicError('2001', new RippleError.ValidationError());
@@ -225,7 +235,7 @@ export default class SologenicTxHandler extends EventEmitter {
   }
 
   private async _connected(): Promise<boolean> {
-    if (this.rippleApi.isConnected()) {
+    if (this.getRippleApi().isConnected()) {
       return true;
     } else {
       await util.promisify(setTimeout)(100);
@@ -261,17 +271,17 @@ export default class SologenicTxHandler extends EventEmitter {
   private async _fetchCurrentState(): Promise<void> {
     try {
       // If the Ripple API is not connected, make sure we connect.
-      if (!this.rippleApi.isConnected()) {
+      if (!this.getRippleApi().isConnected()) {
         await this.connect();
       }
 
       // Use the ripple-lib built in REST functions to get the ledger version and fee. Please note that these
       // values are updated using the WS after the first initilization, until this method is called again
-      this.ledger.ledgerVersion = await this.rippleApi.getLedgerVersion();
-      this.ledger.baseFeeXRP = await this.rippleApi.getFee();
+      this.ledger.ledgerVersion = await this.getRippleApi().getLedgerVersion();
+      this.ledger.baseFeeXRP = await this.getRippleApi().getFee();
 
       // Get account info of the current XRP account and set the sequence to submit transactions
-      const account = await this.rippleApi.request('account_info', {
+      const account = await this.getRippleApi().request('account_info', {
         account: this.account
       });
       this.sequence = account.account_data.Sequence;
@@ -296,21 +306,21 @@ export default class SologenicTxHandler extends EventEmitter {
    */
   private _subscribeWS(): any {
     try {
-      this.rippleApi.on('connect', () => {
+      this.getRippleApi().on('connect', () => {
         // Reconnect
       });
 
-      this.rippleApi.on('disconnect', () => {
-        // Reconnect
-        this.connect();
-      });
-
-      this.rippleApi.on('error', () => {
+      this.getRippleApi().on('disconnect', () => {
         // Reconnect
         this.connect();
       });
 
-      this.rippleApi.on('ledger', ledger => {
+      this.getRippleApi().on('error', () => {
+        // Reconnect
+        this.connect();
+      });
+
+      this.getRippleApi().on('ledger', ledger => {
         // Update the ledger version
         this.ledger = ledger;
       });
@@ -450,7 +460,7 @@ export default class SologenicTxHandler extends EventEmitter {
       const tx = this._addMemo(unsignedTX);
 
       // Make sure the account is valid
-      if (!this.rippleApi.isValidAddress(tx.Account)) {
+      if (!this.getRippleApi().isValidAddress(tx.Account)) {
         throw new SologenicError('2000', new RippleError.ValidationError());
       }
 
@@ -458,7 +468,7 @@ export default class SologenicTxHandler extends EventEmitter {
         // Transaction Specific Settings
         switch (tx.TransactionType) {
           case 'AccountSet':
-            tx.Flags = this.rippleApi.txFlags.Universal.FullyCanonicalSig;
+            tx.Flags = this.getRippleApi().txFlags.Universal.FullyCanonicalSig;
             // JavaScript converts operands to 32-bit signed ints before doing bitwise
             // operations. We need to convert it back to an unsigned int.
             tx.Flags = tx.Flags >>> 0;
@@ -470,7 +480,7 @@ export default class SologenicTxHandler extends EventEmitter {
 
       // multiply the fee by 1.2 to make sure the tx goes through
       // Suggestion. In cases of surge in network fee, this value can be dynamically increased.
-      tx.Fee = this.rippleApi.xrpToDrops(
+      tx.Fee = this.getRippleApi().xrpToDrops(
         this.math.multiply(this.ledger.baseFeeXRP, this.feeCushion).toFixed(6)
       );
 
@@ -481,7 +491,7 @@ export default class SologenicTxHandler extends EventEmitter {
       tx.LastLedgerSequence = this.ledger.ledgerVersion + 3;
 
       // Sign the transaction using the secret provided on init
-      const signedTx: SologenicTypes.signedTX = this.rippleApi.sign(
+      const signedTx: SologenicTypes.signedTX = this.getRippleApi().sign(
         JSON.stringify(tx),
         this.secret
       );
@@ -490,7 +500,7 @@ export default class SologenicTxHandler extends EventEmitter {
       const firstLedgerSequence: number = this.ledger.ledgerVersion;
 
       // Submit the transaction to the ledger
-      const result: SologenicTypes.FormattedSubmitResponse = await this.rippleApi.submit(
+      const result: SologenicTypes.FormattedSubmitResponse = await this.getRippleApi().submit(
         signedTx.signedTransaction
       );
 
@@ -780,7 +790,7 @@ export default class SologenicTxHandler extends EventEmitter {
       // Check and see if the dispatched transaction's ledger is passed or we are in the current ledger
       if (dispatchedTX!.result!.lastLedger <= this.ledger.ledgerVersion) {
         // Get the transaction details from the ledger
-        const validate = await this.rippleApi.getTransaction(
+        const validate = await this.getRippleApi().getTransaction(
           dispatchedTX.result.hash,
           {
             includeRawTransaction: false,
@@ -798,7 +808,7 @@ export default class SologenicTxHandler extends EventEmitter {
         if (exists) {
           // only if the result from the closed ledger is tesSUCCESS, consider this transaction to be final
           if (validate.outcome.result === 'tesSUCCESS') {
-            /* 
+            /*
               add them to `validated` queue for archiving. This queue is not processed and is just for the records.
               Suggestion: add a TTL to these transactions in this queue to avoid overloading Redis and possibly move these
               transactions to a database

--- a/src/lib/stxmq.ts
+++ b/src/lib/stxmq.ts
@@ -61,7 +61,7 @@ export class TXMQƨ {
    *
    * @param queue
    */
-  public async pop(queue: string): Promise<boolean | Array<any>> {
+  public async pop(queue: string): Promise<MQTX | boolean> {
     return this.queue.pop(queue);
   }
 
@@ -70,7 +70,7 @@ export class TXMQƨ {
    * @param queue
    * @param id
    */
-  public async del(queue: string, id: string): Promise<boolean | any[]> {
+  public async del(queue: string, id: string): Promise<boolean> {
     return this.queue.del(queue, id);
   }
 

--- a/src/types/sologenicoptions.d.ts
+++ b/src/types/sologenicoptions.d.ts
@@ -6,8 +6,8 @@ export interface IQueue {
   add(queue: string, data: object, id?: string): Promise<MQTX>;
   get(queue: string, id: string): Promise<MQTX | undefined>;
   getAll(queue: string): Promise<Array<MQTX>>;
-  pop(queue: string): Promise<boolean | Array<any>>
-  del(queue: string, id: string): Promise<boolean | Array<any>>
+  pop(queue: string): Promise<MQTX | boolean>;
+  del(queue: string, id: string): Promise<boolean>;
   delAll(queue: string): Promise<boolean>;
 }
 


### PR DESCRIPTION
Updates for Sologenic Issue #2 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Discussed with Reza to update the pop() and del() method signatures.

```javascript
pop(queue: string): Promise<MQTX | boolean>
del(queue: string, id: string): Promise<boolean>
```

Updated test cases for redis, hash and sologenictxhandler test cases to peform some basic testing.  An example `AcccountSet` transaction is being sent to the XRPL with the hash and redis queues.

Updated sologenictxhandler.ts to check `item.data!.txJSON` instead of `item.txJSON` which was throwing an exception and causing test cases to fail.

* **Other information**:
All test cases passing

```bash
$ export NODE_TLS_REJECT_UNAUTHORIZED=0
$ npm run watch
...

14 tests passed [20:28:57]

  Type `r` and press enter to rerun tests
  Type `u` and press enter to update snapshots
```