### PR TITLE
Add memcache to the docker composer so that we can test memcache loca…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
     restart: unless-stopped
     ports:
       - 127.0.0.1:6379:6379
+
+  memcache:
+    image: sameersbn/memcached:1.5.6-2
+    ports:
+      - 11211:11211
+    restart: unless-stopped

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -5,7 +5,7 @@ export class SologenicError extends Error {
     this.message = this._getError(status);
     Object.setPrototypeOf(this, SologenicError.prototype);
   }
-  
+
   public static getErrorCodes(): Array<any> {
     return [
       { id: '1000', message: 'unspecified_error' },
@@ -16,7 +16,9 @@ export class SologenicError extends Error {
       { id: '1005', message: 'ripple_ws_connection_error' },
       { id: '1006', message: 'unable_to_validate_missed_transactions' },
       { id: '2000', message: 'invalid_xrp_address' },
-      { id: '2001', message: 'invalid_xrp_secret' }
+      { id: '2001', message: 'invalid_xrp_secret' },
+      { id: '2002', message: 'unable_to_get_account_current_state' },
+      { id: '2003', message: 'unable_to_get_account_objects' }
     ]
   }
 

--- a/src/lib/sologenictxhandler.spec.ts
+++ b/src/lib/sologenictxhandler.spec.ts
@@ -64,14 +64,15 @@ test('sologenic tx hash initialization', async t => {
   let handler = new SologenicTxHandler(rippleOptions, thOptions);
   await handler.connect();
 
-  const valid_account: SologenicTypes.Account = (<any>(<any>t.context).valid_account);
-  const invalid_account: SologenicTypes.Account = (<any>(<any>t.context).invalid_account);
+  const valid_account: SologenicTypes.Account = (<SologenicTypes.Account>(<any>t.context).valid_account);
+  const invalid_account: SologenicTypes.Account = (<SologenicTypes.Account>(<any>t.context).invalid_account);
 
   await t.throwsAsync<SologenicError>(handler.setAccount(invalid_account));
 
   await t.notThrowsAsync(handler.setAccount(valid_account));
 });
 
+/*
 test('sologenic tx redis initialization', async t => {
   let rippleOptions: SologenicTypes.RippleAPIOptions = {
     server: (<any>t.context).server,
@@ -92,6 +93,7 @@ test('sologenic tx redis initialization', async t => {
 
   await t.notThrowsAsync(handler.setAccount(valid_account));
 });
+*/
 
 test('submit transaction to xrp ledger on hash queue', async t => {
   try {
@@ -107,7 +109,7 @@ test('submit transaction to xrp ledger on hash queue', async t => {
     let handler: SologenicTxHandler = new SologenicTxHandler(rippleOptions, thOptions);
     await handler.connect();
 
-    await handler.setAccount(<any>(<any>t.context).valid_account);
+    await handler.setAccount(<SologenicTypes.Account>(<any>t.context).valid_account);
 
     let tx: SologenicTypes.TX = {
       Account: <any>(<any>t.context).valid_account.address,
@@ -166,7 +168,7 @@ test('submit transaction to xrp ledger on redis queue', async t => {
     let handler: SologenicTxHandler = new SologenicTxHandler(rippleOptions, thOptions);
     await handler.connect();
 
-    await handler.setAccount(<any>(<any>t.context).valid_account);
+    await handler.setAccount(<SologenicTypes.Account>(<any>t.context).valid_account);
 
     let tx: SologenicTypes.TX = {
       Account: <any>(<any>t.context).valid_account.address,

--- a/src/lib/sologenictxhandler.ts
+++ b/src/lib/sologenictxhandler.ts
@@ -297,6 +297,7 @@ export default class SologenicTxHandler extends EventEmitter {
       // Get account info of the current XRP account and set the sequence to submit transactions
       const account = await this.getRippleApi().getAccountInfo(this.account.address);
 
+      // Update the current account sequence (contains the next sequence that should be used)
       this.account.sequence = account.sequence;
 
     } catch (error) {
@@ -573,7 +574,7 @@ export default class SologenicTxHandler extends EventEmitter {
       );
 
       // increase the sequence for next transaction
-      this.sequence++;
+      this.account.sequence++;
       /*
         If the result code is NOT tesSUCCESS, emit to object listner and globally warning the error.
         Note transaction is not ignore as it could be still validated due to many reasons
@@ -618,7 +619,7 @@ export default class SologenicTxHandler extends EventEmitter {
 
       // 	The address sending the transaction is not funded in the ledger (yet).
       if (result.resultCode === 'terNOaccount') {
-        this.sequence--;
+        this.account.sequence--;
         return await this._txFailed(unsignedTX, 'terNOaccount');
       }
 
@@ -668,7 +669,7 @@ export default class SologenicTxHandler extends EventEmitter {
       // These codes indicate that the transaction failed and was not included in a ledger, but the transaction could have succeeded in some theoretical ledger. Typically this means that the transaction can no longer succeed in any future ledger. They have numerical values in the range -199 to -100. The exact code for any given error is subject to change, so don't rely on it.
       if (result.resultCode.startsWith('tef')) {
         if (result.resultCode === 'tefBAD_AUTH_MASTER') {
-          this.sequence--;
+          this.account.sequence--;
           return await this._txFailed(unsignedTX, result.resultCode);
         }
       }
@@ -715,7 +716,7 @@ export default class SologenicTxHandler extends EventEmitter {
 
       // These codes indicate that the transaction was malformed, and cannot succeed according to the XRP Ledger protocol.
       // if (error) {
-      //   this.sequence--;
+      //   this.account.sequence--;
       //   return await this._txFailed(unsignedTX, 'terNOaccount');
       // }
 

--- a/src/lib/sologenictxhandler_multisigning.spec.ts
+++ b/src/lib/sologenictxhandler_multisigning.spec.ts
@@ -209,3 +209,42 @@ test('send a transaction and pass with quorum requirements being met', async t =
   t.is(result.resultCode, 'tesSUCCESS');
   t.is(result.resultMessage, 'The transaction was applied. Only final in a validated ledger.');
 });
+
+test('check account after assignment to determine if it requires multi-signing', async t => {
+  let handler: SologenicTxHandler = (<any>t.context).handler;
+
+  /* 1,000,000 drops equals 1 XRP (we're sending 0.5 XRP) */
+
+  /*
+  let totalDrops = "500000";
+  let feeInXrp = "0.00012";
+
+  const paymentTx = {
+      TransactionType: "Payment",
+      Account: (<any>t.context).accounts.master.account.address,
+      Amount: totalDrops,
+      Destination: (<any>t.context).accounts.alice.account.address
+    }
+  */
+
+  let xrpAccount: SologenicTypes.Account = {
+    address: (<any>t.context).accounts.master.account.address,
+    secret: (<any>t.context).accounts.master.account.secret
+  };
+
+  xrpAccount.address = (<any>t.context).accounts.master.account.address;
+  xrpAccount.secret = (<any>t.context).accounts.master.account.secret;
+
+  await handler.setAccount(xrpAccount);
+  // await handler.connect();
+
+  const account = handler.getAccount();
+
+  if (!account) {
+    throw new Error("Unable to load account");
+  }
+
+  t.is(account.signers!.length, 3);
+  t.is(account.signers!.length, account.signer_quorum);
+  t.is(account.signer_quorum, 3);
+});

--- a/src/lib/sologenictxhandler_multisigning.spec.ts
+++ b/src/lib/sologenictxhandler_multisigning.spec.ts
@@ -1,0 +1,211 @@
+/*
+If you have problems running these test cases due to a SSL certificate
+issue with the s.devnet.rippletest.net and the nodejs SSL CA bundle, run
+the test cases with the environment variable:
+
+$ NODE_TLS_REJECT_UNAUTHORIZED=0 npm run watch
+*/
+
+import test from 'ava';
+
+import *  as SologenicTypes from '../types';
+import SologenicTxHandler from './sologenictxhandler';
+
+// import { SologenicError } from './error';
+// import { EventEmitter } from 'events';
+
+const _ = require('underscore');
+
+/* Use before each so we use a different address for each request */
+test.before(async t => {
+  _.extend(t.context, {
+    server: "wss://s.devnet.rippletest.net:51233",
+    faucet: "https://faucet.devnet.rippletest.net/accounts",
+  });
+
+  let master = {
+    'account': {
+      'address': 'rnhbLtRcM4PvdiPurLHCUW4Ne7mC34n11w',
+      'secret': 'ssZn7oPLeHqVBNEFhPipbEEuLVDf7'
+    }
+  };
+
+  let alice = {
+    'account': {
+      'address': 'rhqi7fh1Vq7ykn1hcjG6DCVj6urtj6SpAQ',
+      'secret': 'sh1xoGnCVBKXMMqAaEMfNHyMa5Hef'
+    }
+  };
+
+  let bob = {
+    'account': {
+      'address': 'rJB7dTeTkZzvrbErGJdrPdGVirG4okNwVM',
+      'secret': 'ssbxEaHmxh6YhbeUr3XQNghtQ1qwJ'
+    }
+  };
+
+  let charlie = {
+    'account': {
+      'address': 'rKvGgJoAx7N8H63R5bkjmHb9RGH2apjmiG',
+      'secret': 'ssfnNzrBiwxu8eSSy1S3WfRcZpWV9'
+    }
+  };
+
+  _.extend(t.context, {
+    accounts: {
+      master: master,
+      alice: alice,
+      bob: bob,
+      charlie: charlie
+    },
+    xrplOptions: {
+      server: (<any>t.context).server,
+      trace: true
+    },
+    transactionHandlerOptions: {
+      queueType: SologenicTypes.QUEUE_TYPE_STXMQ_HASH,
+    }
+  });
+
+  /* Configure a SignerList */
+  let handler = new SologenicTxHandler(
+    (<any>t.context).xrplOptions,
+    (<any>t.context).transactionHandlerOptions);
+
+  await handler.connect();
+
+  _.extend(t.context, {
+    handler: handler
+  });
+
+  const signerListTx = {
+    Flags: 0,
+    TransactionType: "SignerListSet",
+    Account: master!.account.address,
+    Fee: "10000",
+    SignerQuorum: 3,
+    SignerEntries: [
+      { SignerEntry: { Account: alice!.account.address, SignerWeight: 2 } },
+      { SignerEntry: { Account: bob!.account.address, SignerWeight: 1 } },
+      { SignerEntry: { Account: charlie!.account.address, SignerWeight: 1 } }
+    ]};
+
+    /* Get the next account sequence */
+    const accountInfo = await handler.getRippleApi().getAccountInfo(master!.account.address);
+
+    /* Prepare the signer set list transaction */
+    const preparedTransaction = await handler.getRippleApi().prepareTransaction(signerListTx, {
+      sequence: accountInfo.sequence,
+    });
+
+    const preparedTransactionJson = preparedTransaction.txJSON;
+
+    /* Sign the transaction */
+    const signedSignerListTxJson = handler.getRippleApi().sign(preparedTransactionJson, master!.account.secret);
+
+    /* Submit the transaction to the ledger */
+    let result = await handler.getRippleApi().submit(
+      signedSignerListTxJson.signedTransaction);
+
+    /* tesSUCCESS = 0 */
+    t.is(result.resultCode, "tesSUCCESS");
+    t.is(result.resultMessage, "The transaction was applied. Only final in a validated ledger.");
+  });
+
+test('send a transaction and fail with quorum requirements not being met', async t => {
+  let handler = (<any>t.context).handler;
+
+  /* 1,000,000 drops equals 1 XRP (we're sending 0.5 XRP) */
+  let totalDrops = "500000";
+  let feeInXrp = "0.00012";
+
+  const paymentTx = {
+      TransactionType: "Payment",
+      Account: (<any>t.context).accounts.master.account.address,
+      Amount: totalDrops,
+      Destination: (<any>t.context).accounts.alice.account.address
+    }
+
+  /* Get the next account sequence */
+  const accountInfo = await handler.getRippleApi().getAccountInfo((<any>t.context).accounts.master.account.address);
+
+  /* Prepare the signer set list transaction */
+  const preparedTransaction = await handler.getRippleApi().prepareTransaction(paymentTx, {
+    sequence: parseInt(accountInfo.sequence) + 1,
+    fee: feeInXrp
+  });
+
+  const preparedTransactionJson = preparedTransaction.txJSON;
+
+  /* Sign the transaction as alice */
+  const aliceSignedTransaction = handler.getRippleApi().sign(
+    preparedTransactionJson,
+    (<any>t.context).accounts.alice.account.secret, {
+      signAs: (<any>t.context).accounts.alice.account.address
+    });
+
+  /* Combine the signatures */
+  const signedTransaction = handler.getRippleApi().combine([
+    aliceSignedTransaction.signedTransaction
+  ]);
+
+  /* Submit the transaction to the ledger */
+  let result = await handler.getRippleApi().submit(
+    signedTransaction.signedTransaction);
+
+  t.is(result.resultCode, 'tefBAD_QUORUM');
+  t.is(result.resultMessage, 'Signatures provided do not meet the quorum.');
+});
+
+test('send a transaction and pass with quorum requirements being met', async t => {
+  let handler = (<any>t.context).handler;
+
+  /* 1,000,000 drops equals 1 XRP (we're sending 0.5 XRP) */
+  let totalDrops = "500000";
+  let feeInXrp = "0.00012";
+
+  const paymentTx = {
+      TransactionType: "Payment",
+      Account: (<any>t.context).accounts.master.account.address,
+      Amount: totalDrops,
+      Destination: (<any>t.context).accounts.alice.account.address
+    }
+
+  /* Get the next account sequence */
+  const accountInfo = await handler.getRippleApi().getAccountInfo((<any>t.context).accounts.master.account.address);
+
+  /* Prepare the signer set list transaction */
+  const preparedTransaction = await handler.getRippleApi().prepareTransaction(paymentTx, {
+    sequence: parseInt(accountInfo.sequence) + 1,
+    fee: feeInXrp
+  });
+
+  const preparedTransactionJson = preparedTransaction.txJSON;
+
+  /* Sign the transaction as alice */
+  const aliceSignedTransaction = handler.getRippleApi().sign(
+    preparedTransactionJson,
+    (<any>t.context).accounts.alice.account.secret, {
+      signAs: (<any>t.context).accounts.alice.account.address
+    });
+
+  /* Sign the transaction as alice */
+  const bobSignedTransaction = handler.getRippleApi().sign(
+    preparedTransactionJson,
+    (<any>t.context).accounts.bob.account.secret, {
+      signAs: (<any>t.context).accounts.bob.account.address
+    });
+
+  /* Combine the signatures */
+  const signedTransaction = handler.getRippleApi().combine([
+    aliceSignedTransaction.signedTransaction,
+    bobSignedTransaction.signedTransaction
+  ]);
+
+  /* Submit the transaction to the ledger */
+  let result = await handler.getRippleApi().submit(
+    signedTransaction.signedTransaction);
+
+  t.is(result.resultCode, 'tesSUCCESS');
+  t.is(result.resultMessage, 'The transaction was applied. Only final in a validated ledger.');
+});

--- a/src/types/sologenicoptions.d.ts
+++ b/src/types/sologenicoptions.d.ts
@@ -2,6 +2,8 @@ import { MQTX } from '../types';
 
 import { EventEmitter } from 'events';
 
+import { RippleAPI } from 'ripple-lib';
+
 export interface IQueue {
   add(queue: string, data: object, id?: string): Promise<MQTX>;
   get(queue: string, id: string): Promise<MQTX | undefined>;
@@ -47,6 +49,9 @@ export interface RippleAPIOptions {
 export interface Account {
   address: string;
   secret: string;
+  sequence?: any;
+  signer_quorum?: number;
+  signers?: Array<any>;
 }
 
 export interface Ledger {
@@ -64,6 +69,7 @@ export interface TX {
   Account: string;
   TransactionType: string;
   Memos?: { Memo: any }[];
+  SignedTransactions?: [];
   Flags?: any;
   [Field: string]: string | number | Array<any> | undefined;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add memcached to `docker-compose.yml` to support testing framework.  The tests should eventually be updated to use `localhost` and port `11211` as the default memcached daemon.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
